### PR TITLE
Ftr/service camera commands

### DIFF
--- a/Assets/Magnus/Scripts/CommandSystem/Commands/Camera.meta
+++ b/Assets/Magnus/Scripts/CommandSystem/Commands/Camera.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 84a5e15406e2494cb123abd46663390e
+timeCreated: 1682593096

--- a/Assets/Magnus/Scripts/CommandSystem/Commands/Camera/GetCullingMaskCommand.cs
+++ b/Assets/Magnus/Scripts/CommandSystem/Commands/Camera/GetCullingMaskCommand.cs
@@ -1,0 +1,41 @@
+﻿using Rhinox.Lightspeed;
+using UnityEngine;
+
+namespace Rhinox.Magnus.CommandSystem
+{
+    [CommandInfo("Returns all rendered layers on the main camera", "Camera")]
+    public class GetCullingMaskCommand : IConsoleCommand
+    {
+        public string CommandName => "get-rendered-layers";
+        public string Syntax => "get-rendered-layers";
+
+        public string[] Execute(string[] args)
+        {
+            if (CameraInfo.Instance == null)
+                return new[] { "Camera Info is not loaded." };
+
+            LayerMask layerMask = CameraInfo.Instance.Main.cullingMask;
+
+            string layers = "";
+
+            // Iterate through all possible layers (0 to 31)
+            for (int i = 0; i < 32; i++)
+            {
+                // Shift the layer mask by the current index
+                int shiftedLayer = 1 << i;
+
+                // Check if the current layer is rendered by the camera
+                if ((layerMask & shiftedLayer) == shiftedLayer)
+                {
+                    // Get the name of the layer and add it to the layers string
+                    string layerName = LayerMask.LayerToName(i);
+                    if (layerName.IsNullOrEmpty()) continue;
+
+                    layers += string.IsNullOrEmpty(layers) ? layerName : ", " + layerName;
+                }
+            }
+
+            return new[] { layers };
+        }
+    }
+}

--- a/Assets/Magnus/Scripts/CommandSystem/Commands/Camera/GetCullingMaskCommand.cs.meta
+++ b/Assets/Magnus/Scripts/CommandSystem/Commands/Camera/GetCullingMaskCommand.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 504d994fb25140f3a40fcf6791b4e332
+timeCreated: 1682597494

--- a/Assets/Magnus/Scripts/CommandSystem/Commands/Camera/SetFOVCommand.cs
+++ b/Assets/Magnus/Scripts/CommandSystem/Commands/Camera/SetFOVCommand.cs
@@ -1,0 +1,34 @@
+﻿using Rhinox.Lightspeed;
+using UnityEngine;
+
+namespace Rhinox.Magnus.CommandSystem
+{
+    [CommandInfo("Sets the FOV of the main camera", "Camera")]
+    public class SetFOVCommand : IConsoleCommand
+    {
+        public string CommandName => "set-fov";
+        public string Syntax => "set-fov <angle (degrees)>>";
+
+        public string[] Execute(string[] args)
+        {
+            if(CameraInfo.Instance == null)
+                return new[] { "Camera Info not loaded." };
+            
+            var mainCamera = CameraInfo.Instance.Main;
+            
+            if(mainCamera == null)
+                return new[] { "No main camera found" };
+            
+            if (args.IsNullOrEmpty())
+            {
+                return new[] { $"The current FOV is: {mainCamera.fieldOfView} degrees" };
+            }
+            
+            if(!float.TryParse(args[0], out var fov))
+                return new[] { $"Unable to parse float from {args[0]}" };
+
+            mainCamera.fieldOfView = fov;
+            return new[] { $"The current FOV is: {mainCamera.fieldOfView} degrees" };
+        }
+    }
+}

--- a/Assets/Magnus/Scripts/CommandSystem/Commands/Camera/SetFOVCommand.cs.meta
+++ b/Assets/Magnus/Scripts/CommandSystem/Commands/Camera/SetFOVCommand.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 56a46747177f47b28ef1a09bea4fc218
+timeCreated: 1682593116

--- a/Assets/Magnus/Scripts/CommandSystem/Commands/Camera/ToggleCameraMaskLayer.cs
+++ b/Assets/Magnus/Scripts/CommandSystem/Commands/Camera/ToggleCameraMaskLayer.cs
@@ -1,0 +1,33 @@
+﻿using UnityEngine;
+
+namespace Rhinox.Magnus.CommandSystem
+{
+    [CommandInfo("Toggles a layer in the culling mask of the main camera", "Camera")]
+    public class ToggleCameraMaskLayer : IConsoleCommand
+    {
+        public string CommandName => "toggle-camera-mask-layer";
+        public string Syntax => "toggle-camera-mask-layer <layer>";
+
+        public string[] Execute(string[] args)
+        {
+            if (CameraInfo.Instance == null)
+                return new[] { "Camera Info not loaded." };
+
+            var mainCamera = CameraInfo.Instance.Main;
+
+            if (!UnityTypeParser.TryParseLayer(args[0], out var layerIdx))
+                return new[] { $"Unable to parse layer from {args[0]}" };
+
+            int cullingMask = mainCamera.cullingMask;
+            cullingMask ^= (1 << layerIdx);
+            mainCamera.cullingMask = cullingMask;
+
+            string layerName = LayerMask.LayerToName(layerIdx);
+            string returnString = $"Layer {layerIdx}: {layerName} is";
+
+            return (cullingMask & (1 << layerIdx)) != 0
+                ? new[] { returnString + " now rendered." }
+                : new[] { returnString + " not rendered anymore." };
+        }
+    }
+}

--- a/Assets/Magnus/Scripts/CommandSystem/Commands/Camera/ToggleCameraMaskLayer.cs.meta
+++ b/Assets/Magnus/Scripts/CommandSystem/Commands/Camera/ToggleCameraMaskLayer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 6955c8835983450f9f72535618314d8f
+timeCreated: 1682598325

--- a/Assets/Magnus/Scripts/CommandSystem/Commands/ClearCommand.cs
+++ b/Assets/Magnus/Scripts/CommandSystem/Commands/ClearCommand.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace Rhinox.Magnus.CommandSystem
+{
+    [CommandInfo("Clears the console", "Console")]
+    public class ClearCommand : IConsoleCommand
+    {
+        public string CommandName => "clear";
+        public string Syntax => CommandName;
+
+        public string[] Execute(string[] args)
+        {
+            ConsoleCommandManager.Instance.ClearConsole();
+            return Array.Empty<string>();
+        }
+    }
+}

--- a/Assets/Magnus/Scripts/CommandSystem/Commands/ClearCommand.cs.meta
+++ b/Assets/Magnus/Scripts/CommandSystem/Commands/ClearCommand.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bf6db3e78a2d7ec49a7498487359c12f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Magnus/Scripts/CommandSystem/Commands/GameModeListConsoleCommand.cs
+++ b/Assets/Magnus/Scripts/CommandSystem/Commands/GameModeListConsoleCommand.cs
@@ -10,6 +10,9 @@ namespace Rhinox.Magnus.CommandSystem
 
         public string[] Execute(string[] args)
         {
+            if(GameModeManager.Instance == null)
+                return new[] { "GameModeManager not found." };
+            
             return new[] { string.Join(", ", GameModeManager.Instance.GetModeNames()) };
         }
     }

--- a/Assets/Magnus/Scripts/CommandSystem/Commands/Level.meta
+++ b/Assets/Magnus/Scripts/CommandSystem/Commands/Level.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 40821f0ce023fca4182a8873b5eaa04f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Magnus/Scripts/CommandSystem/Commands/Level/GetActiveLevelCommand.cs
+++ b/Assets/Magnus/Scripts/CommandSystem/Commands/Level/GetActiveLevelCommand.cs
@@ -1,0 +1,14 @@
+﻿namespace Rhinox.Magnus.CommandSystem
+{
+    [CommandInfo("Gets the path of the current level", "Level")]
+    public class GetActiveLevelCommand : IConsoleCommand
+    {
+        public string CommandName => "get-active-level";
+        public string Syntax => "get-active-level";
+
+        public string[] Execute(string[] args)
+        {
+            return new[] { LevelLoader.GetActiveScene() };
+        }
+    }
+}

--- a/Assets/Magnus/Scripts/CommandSystem/Commands/Level/GetActiveLevelCommand.cs.meta
+++ b/Assets/Magnus/Scripts/CommandSystem/Commands/Level/GetActiveLevelCommand.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: c19cac56e71840049f02dbb55dba33c3
+timeCreated: 1682584459

--- a/Assets/Magnus/Scripts/CommandSystem/Commands/Level/GetLevelPath.cs
+++ b/Assets/Magnus/Scripts/CommandSystem/Commands/Level/GetLevelPath.cs
@@ -1,0 +1,20 @@
+﻿using Rhinox.Lightspeed;
+using UnityEngine.SceneManagement;
+
+namespace Rhinox.Magnus.CommandSystem
+{
+    [CommandInfo("Gets the path of a scene with the given name", "Level")]
+    public class GetLevelPath : IConsoleCommand
+    {
+        public string CommandName => "get-level-path";
+        public string Syntax => "get-level-path <scene-name>";
+        public string[] Execute(string[] args)
+        {
+            if(args.IsNullOrEmpty())
+                return new[] { $"Syntax is: {Syntax}" };
+            
+            string returnString = LevelLoader.GetScenePathByName(args[0]);
+            return returnString == "" ? new[] { $"Scene '{args[0]}' was not found..." } : new[] { returnString };
+        }
+    }
+}

--- a/Assets/Magnus/Scripts/CommandSystem/Commands/Level/GetLevelPath.cs.meta
+++ b/Assets/Magnus/Scripts/CommandSystem/Commands/Level/GetLevelPath.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 9e0eb439cfdd41829bb7226bd27a6792
+timeCreated: 1682505198

--- a/Assets/Magnus/Scripts/CommandSystem/Commands/Level/ListLevelsCommand.cs
+++ b/Assets/Magnus/Scripts/CommandSystem/Commands/Level/ListLevelsCommand.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using UnityEngine.SceneManagement;
+
+namespace Rhinox.Magnus.CommandSystem
+{
+    [CommandInfo("Gets all levels in the current build", "Level")]
+    public class ListLevelsCommand : IConsoleCommand
+    {
+        public string CommandName => "list-levels";
+        public string Syntax => "list-levels";
+
+        public string[] Execute(string[] args)
+        {
+            int sceneCount = SceneManager.sceneCountInBuildSettings;
+            string returnString = "";
+            for (int i = 0; i < sceneCount; i++)
+            {
+                string scenePath = SceneUtility.GetScenePathByBuildIndex(i);
+                string sceneName = System.IO.Path.GetFileNameWithoutExtension(scenePath);
+                returnString += $"{i}: {sceneName}\n";
+            }
+
+            return new[] { returnString };
+        }
+    }
+}

--- a/Assets/Magnus/Scripts/CommandSystem/Commands/Level/ListLevelsCommand.cs.meta
+++ b/Assets/Magnus/Scripts/CommandSystem/Commands/Level/ListLevelsCommand.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 13d1ffca92914030a3214179798e3a75
+timeCreated: 1682500246

--- a/Assets/Magnus/Scripts/CommandSystem/Commands/Level/LoadLevelCommand.cs
+++ b/Assets/Magnus/Scripts/CommandSystem/Commands/Level/LoadLevelCommand.cs
@@ -14,8 +14,12 @@ namespace Rhinox.Magnus.CommandSystem
             
             if(!int.TryParse(args[0], out int sceneIndex))
                 return new[] { $"Scene index must be an integer: {args[0]}" };
-            
-            LevelLoader.Instance.LoadScene(sceneIndex);
+
+            LevelLoader loader = LevelLoader.Instance;
+            if(loader == null)
+                return new[] { "No level loader found" };
+
+            loader.LoadScene(sceneIndex);
             return new[] { $"Attempting to load scene {sceneIndex}" };
         }
     }

--- a/Assets/Magnus/Scripts/CommandSystem/Commands/Level/LoadLevelCommand.cs
+++ b/Assets/Magnus/Scripts/CommandSystem/Commands/Level/LoadLevelCommand.cs
@@ -1,0 +1,22 @@
+﻿using Rhinox.Lightspeed;
+
+namespace Rhinox.Magnus.CommandSystem
+{
+    [CommandInfo("Loads a scene using the LevelLoader", "Level")]
+    public class LoadLevelCommand:IConsoleCommand
+    {
+        public string CommandName => "load-level";
+        public string Syntax => "load-level <scene-index>";
+        public string[] Execute(string[] args)
+        {
+            if(args.IsNullOrEmpty())
+                return new[] { $"Syntax is: {Syntax}" };
+            
+            if(!int.TryParse(args[0], out int sceneIndex))
+                return new[] { $"Scene index must be an integer: {args[0]}" };
+            
+            LevelLoader.Instance.LoadScene(sceneIndex);
+            return new[] { $"Attempting to load scene {sceneIndex}" };
+        }
+    }
+}

--- a/Assets/Magnus/Scripts/CommandSystem/Commands/Level/LoadLevelCommand.cs.meta
+++ b/Assets/Magnus/Scripts/CommandSystem/Commands/Level/LoadLevelCommand.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 8b7f0af641bd439ea787a68a422e0776
+timeCreated: 1682505540

--- a/Assets/Magnus/Scripts/CommandSystem/Commands/Player.meta
+++ b/Assets/Magnus/Scripts/CommandSystem/Commands/Player.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d5fad9bd2b858a241b72e8ab3797a2ce
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Magnus/Scripts/CommandSystem/Commands/Player/KillPlayerCommand.cs
+++ b/Assets/Magnus/Scripts/CommandSystem/Commands/Player/KillPlayerCommand.cs
@@ -8,7 +8,11 @@
 
         public string[] Execute(string[] args)
         {
-            PlayerManager.Instance.KillPlayer();
+            var playerManager = PlayerManager.Instance;
+            if(playerManager == null)
+                return new[] { "No Player Manager found." };
+            
+            playerManager.KillPlayer();
             return new[] { "Player killed." };
         }
     }

--- a/Assets/Magnus/Scripts/CommandSystem/Commands/Player/KillPlayerCommand.cs
+++ b/Assets/Magnus/Scripts/CommandSystem/Commands/Player/KillPlayerCommand.cs
@@ -1,0 +1,15 @@
+﻿namespace Rhinox.Magnus.CommandSystem.Player
+{
+    [CommandInfo("Kills the loaded player", "Player")]
+    public class KillPlayerCommand : IConsoleCommand
+    {
+        public string CommandName => "kill-player";
+        public string Syntax => "kill-player";
+
+        public string[] Execute(string[] args)
+        {
+            PlayerManager.Instance.KillPlayer();
+            return new[] { "Player killed." };
+        }
+    }
+}

--- a/Assets/Magnus/Scripts/CommandSystem/Commands/Player/KillPlayerCommand.cs.meta
+++ b/Assets/Magnus/Scripts/CommandSystem/Commands/Player/KillPlayerCommand.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: cedfa685ab6a4d6b8656c4a215254505
+timeCreated: 1682587502

--- a/Assets/Magnus/Scripts/CommandSystem/Commands/Player/RespawnPlayerCommand.cs
+++ b/Assets/Magnus/Scripts/CommandSystem/Commands/Player/RespawnPlayerCommand.cs
@@ -11,36 +11,32 @@ namespace Rhinox.Magnus.CommandSystem.Player
 
         public string[] Execute(string[] args)
         {
-            if (args.IsNullOrEmpty())
-            {
-                PlayerManager.Instance.RespawnPlayer();
-                return new[] { "Player respawned." };
-            }
+            if (PlayerManager.Instance == null)
+                return new[] { "No player manager found" };
 
-            if (!UnityTypeParser.TryParseVector3(args[0], out Vector3 position))
+            Vector3 position = Vector3.zero;
+            Vector3 eulerAngles = Vector3.zero;
+            bool persistent = false;
+            Quaternion rotation;
+
+            // If there are arguments, attempt to parse them according to the amount of arguments
+            // (See Syntax)
+            if (args.Length > 0 && !UnityTypeParser.TryParseVector3(args[0], out position))
                 return new[] { "Unable to parse position, format is x,y,z" };
 
-            if (args.Length == 1)
-            {
-                PlayerManager.Instance.RespawnPlayer(position);
-                return new[] { $"Player respawned at position {position}" };
-            }
-
-            if (!UnityTypeParser.TryParseVector3(args[1], out Vector3 rotation))
+            if (args.Length > 1 && !UnityTypeParser.TryParseVector3(args[1], out eulerAngles))
                 return new[] { "Unable to parse rotation, format is x,y,z" };
-            Quaternion rot = Quaternion.Euler(rotation);
-
-            if (args.Length == 2)
-            {
-                PlayerManager.Instance.RespawnPlayer(position, rot);
-                return new[] { $"Player respawned at position {position}, with rotation {rotation}" };
-            }
-
-            if (!bool.TryParse(args[2], out bool persistent))
-                return new[] { "Unable to parse persistent, format is true/false" };
             
-            PlayerManager.Instance.RespawnPlayer(position, rot, persistent);
-            return new[] { $"Player respawned at position {position}, with rotation {rotation}, and persistent {persistent}" };
+            rotation = Quaternion.Euler(eulerAngles);
+
+            if (args.Length > 2 && !bool.TryParse(args[2], out persistent))
+                return new[] { "Unable to parse persistent, format is true/false" };
+
+            PlayerManager.Instance.RespawnPlayer(position, rotation, persistent);
+            return new[]
+            {
+                $"Player respawned at position {position}, with rotation {eulerAngles}, and persistent {persistent}"
+            };
         }
     }
 }

--- a/Assets/Magnus/Scripts/CommandSystem/Commands/Player/RespawnPlayerCommand.cs
+++ b/Assets/Magnus/Scripts/CommandSystem/Commands/Player/RespawnPlayerCommand.cs
@@ -1,0 +1,46 @@
+﻿using Rhinox.Lightspeed;
+using UnityEngine;
+
+namespace Rhinox.Magnus.CommandSystem.Player
+{
+    [CommandInfo("Respawns the player", "Player")]
+    public class RespawnPlayerCommand : IConsoleCommand
+    {
+        public string CommandName => "respawn-player";
+        public string Syntax => "respawn-player [<position x,y,z> <rotation x,y,z> <persistent>]";
+
+        public string[] Execute(string[] args)
+        {
+            if (args.IsNullOrEmpty())
+            {
+                PlayerManager.Instance.RespawnPlayer();
+                return new[] { "Player respawned." };
+            }
+
+            if (!UnityTypeParser.TryParseVector3(args[0], out Vector3 position))
+                return new[] { "Unable to parse position, format is x,y,z" };
+
+            if (args.Length == 1)
+            {
+                PlayerManager.Instance.RespawnPlayer(position);
+                return new[] { $"Player respawned at position {position}" };
+            }
+
+            if (!UnityTypeParser.TryParseVector3(args[1], out Vector3 rotation))
+                return new[] { "Unable to parse rotation, format is x,y,z" };
+            Quaternion rot = Quaternion.Euler(rotation);
+
+            if (args.Length == 2)
+            {
+                PlayerManager.Instance.RespawnPlayer(position, rot);
+                return new[] { $"Player respawned at position {position}, with rotation {rotation}" };
+            }
+
+            if (!bool.TryParse(args[2], out bool persistent))
+                return new[] { "Unable to parse persistent, format is true/false" };
+            
+            PlayerManager.Instance.RespawnPlayer(position, rot, persistent);
+            return new[] { $"Player respawned at position {position}, with rotation {rotation}, and persistent {persistent}" };
+        }
+    }
+}

--- a/Assets/Magnus/Scripts/CommandSystem/Commands/Player/RespawnPlayerCommand.cs.meta
+++ b/Assets/Magnus/Scripts/CommandSystem/Commands/Player/RespawnPlayerCommand.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 970ecab827a9498ea36227b55cbba049
+timeCreated: 1682585057

--- a/Assets/Magnus/Scripts/CommandSystem/Commands/Services/ListServicesCommand.cs
+++ b/Assets/Magnus/Scripts/CommandSystem/Commands/Services/ListServicesCommand.cs
@@ -1,0 +1,17 @@
+﻿using System.Linq;
+
+namespace Rhinox.Magnus.CommandSystem
+{
+    [CommandInfo("Lists all available services", "Services")]
+    public class ListServicesCommand : IConsoleCommand
+    {
+        public string CommandName => "list-services";
+        public string Syntax => CommandName;
+
+        public string[] Execute(string[] args)
+        {
+            var services = Services.GetAvailableServices();
+            return new[] { string.Join(", ", services.Select(x => x.Name).ToArray()) };
+        }
+    }
+}

--- a/Assets/Magnus/Scripts/CommandSystem/Commands/Services/ListServicesCommand.cs.meta
+++ b/Assets/Magnus/Scripts/CommandSystem/Commands/Services/ListServicesCommand.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 0fa3cfcfbbfa446bb6b2e085606b4b08
+timeCreated: 1682493946

--- a/Assets/Magnus/Scripts/CommandSystem/Commands/SwitchToModeConsoleCommand.cs
+++ b/Assets/Magnus/Scripts/CommandSystem/Commands/SwitchToModeConsoleCommand.cs
@@ -12,6 +12,9 @@ namespace Rhinox.Magnus.CommandSystem
 
         public string[] Execute(string[] args)
         {
+            if (GameModeManager.Instance == null)
+                return new[] { "GameModeManager not found." };
+            
             if (args.IsNullOrEmpty())
                 return new[] { "Missing argument: <mode name>" };
             string modeName = args.First();

--- a/Assets/Magnus/Scripts/CommandSystem/Commands/Unity/Layer.meta
+++ b/Assets/Magnus/Scripts/CommandSystem/Commands/Unity/Layer.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 9be844e1603a48d9bee725a4f2fb8b24
+timeCreated: 1682496567

--- a/Assets/Magnus/Scripts/CommandSystem/Commands/Unity/Layer/ListLayersCommand.cs
+++ b/Assets/Magnus/Scripts/CommandSystem/Commands/Unity/Layer/ListLayersCommand.cs
@@ -1,0 +1,25 @@
+﻿using System.Linq;
+using Rhinox.Lightspeed;
+using UnityEngine;
+
+namespace Rhinox.Magnus.CommandSystem
+{
+    [CommandInfo("Lists all named layers", "Layers")]
+    public class ListLayersCommand:IConsoleCommand
+    {
+        public string CommandName => "list-layers";
+        public string Syntax => CommandName;
+        public string[] Execute(string[] args)
+        {
+            string layerNames = "";
+            for (int i = 0; i < 32; i++)
+            {
+                string layerName = LayerMask.LayerToName(i);
+                if(!layerName.IsNullOrEmpty())
+                    layerNames += LayerMask.LayerToName(i) + " ";
+            }
+            
+            return new[] { layerNames };
+        }
+    }
+}

--- a/Assets/Magnus/Scripts/CommandSystem/Commands/Unity/Layer/ListLayersCommand.cs.meta
+++ b/Assets/Magnus/Scripts/CommandSystem/Commands/Unity/Layer/ListLayersCommand.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 83d9f4b2142246b689acc14491143adc
+timeCreated: 1682496158

--- a/Assets/Magnus/Scripts/CommandSystem/Commands/Unity/Layer/SetLayerCommand.cs
+++ b/Assets/Magnus/Scripts/CommandSystem/Commands/Unity/Layer/SetLayerCommand.cs
@@ -1,0 +1,35 @@
+﻿using Rhinox.Lightspeed;
+using UnityEngine;
+
+namespace Rhinox.Magnus.CommandSystem
+{
+    [CommandInfo("Sets the layer of a GameObject using the LayerManager", "Layers")]
+    public class SetLayerCommand : BaseGameObjectConsoleCommand
+    {
+        public override string CommandName => "set-layer";
+        public override string Syntax => "set-layer <name> <layer>";
+
+        protected override string[] ExecuteFor(GameObject go, string[] args)
+        {
+            if (args.IsNullOrEmpty())
+                return new[] { "Missing argument <layer>" };
+            
+            // Check if the given string is an integer
+            if (int.TryParse(args[0], out int layerIdx))
+            {
+                // Check if the layerIdx is in the range of the layer mask
+                if (layerIdx < 0 || layerIdx >= 31)
+                    return new[] { $"LayerIndex '{args[0]}' is not valid. Should be in the range [0;31]." };
+            }
+            else
+                layerIdx = LayerMask.NameToLayer(args[0]);
+
+            if (layerIdx == -1)
+                return new[] { $"Layer '{args[0]}' not found." };
+
+            LayerManager.Instance.SetLayer(go, layerIdx);
+
+            return new[] { $"Layer of {go.name} set to {layerIdx}" };
+        }
+    }
+}

--- a/Assets/Magnus/Scripts/CommandSystem/Commands/Unity/Layer/SetLayerCommand.cs
+++ b/Assets/Magnus/Scripts/CommandSystem/Commands/Unity/Layer/SetLayerCommand.cs
@@ -11,25 +11,18 @@ namespace Rhinox.Magnus.CommandSystem
 
         protected override string[] ExecuteFor(GameObject go, string[] args)
         {
+            if(LayerManager.Instance == null)
+                return new[] { "LayerManager not found." };
+            
             if (args.IsNullOrEmpty())
                 return new[] { "Missing argument <layer>" };
             
-            // Check if the given string is an integer
-            if (int.TryParse(args[0], out int layerIdx))
-            {
-                // Check if the layerIdx is in the range of the layer mask
-                if (layerIdx < 0 || layerIdx >= 31)
-                    return new[] { $"LayerIndex '{args[0]}' is not valid. Should be in the range [0;31]." };
-            }
-            else
-                layerIdx = LayerMask.NameToLayer(args[0]);
-
-            if (layerIdx == -1)
-                return new[] { $"Layer '{args[0]}' not found." };
+            if(!UnityTypeParser.TryParseLayer(args[0], out var layerIdx))
+                return new[] { $"Unable to parse layer from {args[0]}" };
 
             LayerManager.Instance.SetLayer(go, layerIdx);
 
-            return new[] { $"Layer of {go.name} set to {layerIdx}" };
+            return new[] { $"Layer of {go.name} set to {layerIdx}: {LayerMask.LayerToName(layerIdx)}" };
         }
     }
 }

--- a/Assets/Magnus/Scripts/CommandSystem/Commands/Unity/Layer/SetLayerCommand.cs.meta
+++ b/Assets/Magnus/Scripts/CommandSystem/Commands/Unity/Layer/SetLayerCommand.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 650dc926b31544ff80bf1e0947a6f662
+timeCreated: 1682494486

--- a/Assets/Magnus/Scripts/CommandSystem/Commands/Unity/Layer/UnsetLayer.cs
+++ b/Assets/Magnus/Scripts/CommandSystem/Commands/Unity/Layer/UnsetLayer.cs
@@ -1,0 +1,27 @@
+﻿using Rhinox.Lightspeed;
+using UnityEngine;
+
+namespace Rhinox.Magnus.CommandSystem
+{
+    [CommandInfo("Unsets the layer of a GameObject using the LayerManager", "Layers")]
+    public class UnsetLayer : BaseGameObjectConsoleCommand
+    {
+        public override string CommandName => "unset-layer";
+        public override string Syntax => "unset-layer <name> <layer>";
+        
+        protected override string[] ExecuteFor(GameObject go, string[] args)
+        {
+            if(args.IsNullOrEmpty())
+                return new[] { "Missing argument <layer>" };
+
+            if (!int.TryParse(args[0], out int layerIdx))
+            {
+                layerIdx = LayerMask.NameToLayer(args[0]);
+            }
+
+            LayerManager.Instance.UnsetLayer(go, layerIdx);
+            
+            return new[] { $"Layer of {go.name} unset {layerIdx}" };
+        }
+    }
+}

--- a/Assets/Magnus/Scripts/CommandSystem/Commands/Unity/Layer/UnsetLayer.cs
+++ b/Assets/Magnus/Scripts/CommandSystem/Commands/Unity/Layer/UnsetLayer.cs
@@ -11,6 +11,9 @@ namespace Rhinox.Magnus.CommandSystem
         
         protected override string[] ExecuteFor(GameObject go, string[] args)
         {
+            if (LayerManager.Instance == null)
+                return new[] { "LayerManager not found." };
+            
             if(args.IsNullOrEmpty())
                 return new[] { "Missing argument <layer>" };
 

--- a/Assets/Magnus/Scripts/CommandSystem/Commands/Unity/Layer/UnsetLayer.cs.meta
+++ b/Assets/Magnus/Scripts/CommandSystem/Commands/Unity/Layer/UnsetLayer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 9cb4e55818824f1b810f6edab2b18dd2
+timeCreated: 1682496578

--- a/Assets/Magnus/Scripts/CommandSystem/ConsoleCommandManager.cs
+++ b/Assets/Magnus/Scripts/CommandSystem/ConsoleCommandManager.cs
@@ -248,5 +248,11 @@ namespace Rhinox.Magnus.CommandSystem
                 return;
             _guiAccessEnabled = true;
         }
+
+        public void ClearConsole()
+        {
+            _commandViewIMGUI?.Clear();
+            
+        }
     }
 }

--- a/Assets/Magnus/Scripts/CommandSystem/ConsoleCommandViewIMGUI.cs
+++ b/Assets/Magnus/Scripts/CommandSystem/ConsoleCommandViewIMGUI.cs
@@ -51,7 +51,7 @@ namespace Rhinox.Magnus.CommandSystem
 
             GUIStyle defaultLabelStyle = ConsoleGUIStyles.ConsoleLabelStyle;
             _labelHeight =
-                defaultLabelStyle.CalcHeight(new GUIContent("Sample Label"), EditorGUIUtility.currentViewWidth);
+                defaultLabelStyle.CalcHeight(new GUIContent("Sample Label"), WINDOW_WIDTH);
         }
 
         private void Start()

--- a/Assets/Magnus/Scripts/CommandSystem/ConsoleCommandViewIMGUI.cs
+++ b/Assets/Magnus/Scripts/CommandSystem/ConsoleCommandViewIMGUI.cs
@@ -280,5 +280,12 @@ namespace Rhinox.Magnus.CommandSystem
         #region RuntimeGUIStyles
 
         #endregion
+
+        public void Clear()
+        {
+            _commandHistory.Clear();
+            _outputHistory.Clear();
+            _suggestions.Clear();
+        }
     }
 }

--- a/Assets/Magnus/Scripts/CommandSystem/ConsoleGUIStyles.cs
+++ b/Assets/Magnus/Scripts/CommandSystem/ConsoleGUIStyles.cs
@@ -1,7 +1,4 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using UnityEditor;
-using UnityEngine;
+﻿using UnityEngine;
 
 public static class ConsoleGUIStyles
 {
@@ -20,7 +17,7 @@ public static class ConsoleGUIStyles
                     padding = new RectOffset(0, 0, 0, 0),
                     normal =
                     {
-                        background = EditorGUIUtility.whiteTexture
+                        background = Texture2D.whiteTexture
                     }
                 };
             }

--- a/Assets/Magnus/Scripts/LevelLoader/LevelLoader.cs
+++ b/Assets/Magnus/Scripts/LevelLoader/LevelLoader.cs
@@ -151,6 +151,12 @@ namespace Rhinox.Magnus
         /// <param name="sceneRequestString">Scene name or path</param>
         public void LoadScene(string sceneRequestString)
         {
+            if (!IsConfiguredAndEnabled())
+            {
+                PLog.Warn<MagnusLogger>("LevelLoader not configured correctly in Project Settings");
+                return;
+            }
+            
             if (_runningLoad)
             {
                 PLog.Error<MagnusLogger>($"Can't transition to new scene, load is still running...");
@@ -182,6 +188,11 @@ namespace Rhinox.Magnus
         
         public void LoadScene(LevelDefinitionData scene)
         {
+            if (!IsConfiguredAndEnabled())
+            {
+                PLog.Warn<MagnusLogger>("LevelLoader not configured correctly in Project Settings");
+                return;
+            }
             if (_runningLoad)
             {
                 PLog.Error<MagnusLogger>($"Can't transition to new scene, load is still running...");
@@ -201,6 +212,11 @@ namespace Rhinox.Magnus
 
         public void LoadScene(int buildIndex)
         {
+            if (!IsConfiguredAndEnabled())
+            {
+                PLog.Warn<MagnusLogger>("LevelLoader not configured correctly in Project Settings");
+                return;
+            }
             if (_runningLoad)
             {
                 PLog.Error<MagnusLogger>($"Can't transition to new scene, load is still running...");
@@ -220,6 +236,11 @@ namespace Rhinox.Magnus
         
         public void ReloadScene()
         {
+            if (!IsConfiguredAndEnabled())
+            {
+                PLog.Warn<MagnusLogger>("LevelLoader not configured correctly in Project Settings");
+                return;
+            }
             if (_runningLoad)
             {
                 PLog.Error<MagnusLogger>($"Can't transition to new scene, load is still running...");
@@ -275,7 +296,7 @@ namespace Rhinox.Magnus
         }
 
         private IEnumerator GoToLevelLoadingArea(bool skipTransition, bool changingActiveScene)
-        {
+        { 
             LevelLoadingArea area = Object.FindObjectsOfType<LevelLoaderAreaOverride>()
                 .FirstOrDefault(x => x.gameObject.scene.path.Equals(_scenePathTransitionTarget))
                 ?.Area;
@@ -283,6 +304,7 @@ namespace Rhinox.Magnus
             if (area == null)
                 area = MagnusProjectSettings.Instance.LoadingScenePrefab;
             
+            // Attempts instantiate even if are is still null?
             if (_activeArea == null)
                 _activeArea = Object.Instantiate(area, _offworldLocation, Quaternion.identity, transform);
             
@@ -739,7 +761,7 @@ namespace Rhinox.Magnus
         }
         
         // TODO: port to Rhinox.Utilities
-        private static string GetScenePathByName(string name)
+        public static string GetScenePathByName(string name)
         {
             int i = 0;
             string sceneName = "FOOBAR";

--- a/Assets/Magnus/Scripts/Services/CameraInfo.cs
+++ b/Assets/Magnus/Scripts/Services/CameraInfo.cs
@@ -1,5 +1,6 @@
-/*using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Diagnostics;
+using Rhinox.Lightspeed;
 using UnityEngine;
 using UnityEngine.Rendering;
 using Debug = UnityEngine.Debug;
@@ -11,14 +12,14 @@ namespace Rhinox.Magnus
     {
         private List<Camera> _activeCameras;
         private List<Camera> _previousFrameCameras;
-        
-        public IReadOnlyList<Camera> ActiveCameras => _activeCameras.AsReadOnly(); 
+
+        public IReadOnlyList<Camera> ActiveCameras => _activeCameras.AsReadOnly();
         private const string MainCameraTag = "MainCamera";
 
         public Camera Main => GetMainCamera();
 
         public delegate void CameraDelegate(Camera cameras);
-        
+
         public event CameraDelegate CameraDisabled;
         public event CameraDelegate NewActiveCamera;
 
@@ -35,7 +36,7 @@ namespace Rhinox.Magnus
         protected override void Update()
         {
             var sw = Stopwatch.StartNew();
-            // Track whether any cameras were diabled
+            // Track whether any cameras were disabled
             for (var i = 0; i < _activeCameras.Count; i++)
             {
                 var c = _activeCameras[i];
@@ -43,7 +44,7 @@ namespace Rhinox.Magnus
                 if (!_previousFrameCameras.Contains(c))
                     OnCameraDisabled(c);
             }
-            
+
             // Track whether there are any new cameras
             for (var i = 0; i < _previousFrameCameras.Count; i++)
             {
@@ -52,16 +53,17 @@ namespace Rhinox.Magnus
                 if (!_activeCameras.Contains(c))
                     OnNewActiveCamera(c);
             }
+
             sw.Stop();
-            Debug.Log("[CameraInfo::Update::Events] Took " + sw.Elapsed.TotalMilliseconds.ToString("#.000") + "ms");
+            //Debug.Log("[CameraInfo::Update::Events] Took " + sw.Elapsed.TotalMilliseconds.ToString("#.000") + "ms");
             sw.Restart();
 
             // Swap the list so we don't need to create new ones
             Utility.Swap(ref _activeCameras, ref _previousFrameCameras);
             _previousFrameCameras.Clear();
-            
+
             sw.Stop();
-            Debug.Log("[CameraInfo::Update::Swap] Took " + sw.Elapsed.TotalMilliseconds.ToString("#.000") + "ms");
+            //Debug.Log("[CameraInfo::Update::Swap] Took " + sw.Elapsed.TotalMilliseconds.ToString("#.000") + "ms");
         }
 
         private void OnNewActiveCamera(Camera c)
@@ -75,7 +77,7 @@ namespace Rhinox.Magnus
             CameraDisabled?.Invoke(c);
             Debug.Log("Camera Disabled: " + c.name);
         }
-        
+
 #if UNITY_2019_1_OR_NEWER
         private void OnCameraRendering(ScriptableRenderContext context, Camera[] cameras)
         {
@@ -83,12 +85,12 @@ namespace Rhinox.Magnus
                 HandleCamera(cameras[i]);
         }
 #endif
-        
+
         private void HandleCamera(Camera cam)
         {
             _previousFrameCameras.Add(cam);
         }
-        
+
         private Camera GetMainCamera()
         {
             for (int i = 0; i < _activeCameras.Count; ++i)
@@ -100,4 +102,4 @@ namespace Rhinox.Magnus
             return null;
         }
     }
-}*/
+}

--- a/Assets/Magnus/Scripts/Utils.meta
+++ b/Assets/Magnus/Scripts/Utils.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 54b7ae4b9b041c946ade8ac6ea6ed4a6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Magnus/Scripts/Utils/UnityTypeParser.cs
+++ b/Assets/Magnus/Scripts/Utils/UnityTypeParser.cs
@@ -1,0 +1,64 @@
+﻿using UnityEngine;
+
+namespace Rhinox.Magnus
+{
+    public static class UnityTypeParser
+    {
+        /// <summary>
+        /// Attempts to parse a Vector3 from a string of following format:
+        /// x,y,z
+        /// </summary>
+        /// <param name="input">The string holding the info.</param>
+        /// <param name="result">Out Vector3 parameters for the result (if successful).</param>
+        /// <returns></returns>
+        public static bool TryParseVector3(string input, out Vector3 result)
+        {
+            // Reset the result
+            result = Vector3.zero;
+
+            //Split the given string into substrings
+            string[] values = input.Split(',');
+            if (values.Length != 3)
+                return false;
+
+            // Attempt to parse the individual floats
+            if (!float.TryParse(values[0], out float x) ||
+                !float.TryParse(values[1], out float y) ||
+                !float.TryParse(values[2], out float z))
+                return false;
+
+            // Set the result
+            result = new Vector3(x, y, z);
+            return true;
+        }
+
+        /// <summary>
+        /// Attempts to parse a Quaternion from a string of following format:
+        /// x,y,z,w
+        /// </summary>
+        /// <param name="input">The string holding the info.</param>
+        /// <param name="result">Out Quaternion parameters for the result (if successful).</param>
+        /// <returns></returns>
+        public static bool TryParseQuaternion(string input, out Quaternion result)
+        {
+            // Reset the result
+            result = Quaternion.identity;
+
+            //Split the given string into substrings
+            string[] values = input.Split(',');
+            if (values.Length != 4)
+                return false;
+
+            // Attempt to parse the individual floats
+            if (!float.TryParse(values[0], out float x) ||
+                !float.TryParse(values[1], out float y) ||
+                !float.TryParse(values[2], out float z) ||
+                !float.TryParse(values[3], out float w))
+                return false;
+            
+            // Set the result
+            result = new Quaternion(x, y, z, w);
+            return true;
+        }
+    }
+}

--- a/Assets/Magnus/Scripts/Utils/UnityTypeParser.cs
+++ b/Assets/Magnus/Scripts/Utils/UnityTypeParser.cs
@@ -55,10 +55,51 @@ namespace Rhinox.Magnus
                 !float.TryParse(values[2], out float z) ||
                 !float.TryParse(values[3], out float w))
                 return false;
-            
+
             // Set the result
             result = new Quaternion(x, y, z, w);
             return true;
+        }
+
+        /// <summary>
+        /// Tries to parse a layer from a given string. The string can either be the name of the layer or the index.
+        /// </summary>
+        /// <param name="input">The input string representing either the name or the index of the layer.</param>
+        /// <param name="layer">The output layer number if the input is valid, otherwise -1.</param>
+        /// <returns>True if the input is valid and a layer is parsed, otherwise false.</returns>
+        public static bool TryParseLayer(string input, out int layer)
+        {
+            layer = -1;
+
+            if (int.TryParse(input, out int layerIndex))
+            {
+                if (IsValidLayerIndex(layerIndex))
+                {
+                    layer = layerIndex;
+                    return true;
+                }
+            }
+            else
+            {
+                int layerId = LayerMask.NameToLayer(input);
+                if (IsValidLayerIndex(layerId))
+                {
+                    layer = layerId;
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Checks if the layer index is valid.
+        /// </summary>
+        /// <param name="layerIndex">The layer index to be checked.</param>
+        /// <returns>True if the layer index is valid, otherwise false.</returns>
+        private static bool IsValidLayerIndex(int layerIndex)
+        {
+            return layerIndex >= 0 && layerIndex < 32;
         }
     }
 }

--- a/Assets/Magnus/Scripts/Utils/UnityTypeParser.cs.meta
+++ b/Assets/Magnus/Scripts/Utils/UnityTypeParser.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cdf2d7f8fa05a9a4ca5c09cf05ecf913
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Magnus/package.json
+++ b/Assets/Magnus/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.rhinox.open.magnus",
   "displayName": "Magnus - Game Framework",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "unity": "2019.4",
   "description": "Game Framework built on top of Unity",
   "keywords": [
@@ -11,8 +11,8 @@
   "category": "Unity",
   "dependencies": {
 	"com.unity.nuget.newtonsoft-json": "2.0.0",
-	"com.rhinox.open.lightspeed": "1.5.5",
-	"com.rhinox.open.guiutils": "2.7.0",
+	"com.rhinox.open.lightspeed": "1.5.8",
+	"com.rhinox.open.guiutils": "2.8.1",
 	"com.rhinox.open.perceptor": "0.2.0",
     "com.rhinox.open.utilities": "1.5.4",
     "com.unity.textmeshpro": "2.1.6",

--- a/Assets/Test/LevelLoadingAreaTest.prefab
+++ b/Assets/Test/LevelLoadingAreaTest.prefab
@@ -1,0 +1,59 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2614632452621788367
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4788271035113731686}
+  - component: {fileID: 8379233905309256205}
+  - component: {fileID: 134583676349746417}
+  m_Layer: 0
+  m_Name: LevelLoadingAreaTest
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4788271035113731686
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2614632452621788367}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -3.3847442, y: 447.18982, z: -165.31854}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &8379233905309256205
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2614632452621788367}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 812e75ac17d2419484106658844876f0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &134583676349746417
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2614632452621788367}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cb3561d775174398a3df98ff3365c61f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Area: {fileID: 8379233905309256205}

--- a/Assets/Test/LevelLoadingAreaTest.prefab.meta
+++ b/Assets/Test/LevelLoadingAreaTest.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 07043005be65ef0468a79fed1551e557
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Test/Scene/emptyScene2.unity
+++ b/Assets/Test/Scene/emptyScene2.unity
@@ -296,3 +296,72 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &8740602621077918145
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2614632452621788367, guid: 07043005be65ef0468a79fed1551e557,
+        type: 3}
+      propertyPath: m_Name
+      value: LevelLoadingAreaTest
+      objectReference: {fileID: 0}
+    - target: {fileID: 4788271035113731686, guid: 07043005be65ef0468a79fed1551e557,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4788271035113731686, guid: 07043005be65ef0468a79fed1551e557,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3.3847442
+      objectReference: {fileID: 0}
+    - target: {fileID: 4788271035113731686, guid: 07043005be65ef0468a79fed1551e557,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 447.18982
+      objectReference: {fileID: 0}
+    - target: {fileID: 4788271035113731686, guid: 07043005be65ef0468a79fed1551e557,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -165.31854
+      objectReference: {fileID: 0}
+    - target: {fileID: 4788271035113731686, guid: 07043005be65ef0468a79fed1551e557,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4788271035113731686, guid: 07043005be65ef0468a79fed1551e557,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4788271035113731686, guid: 07043005be65ef0468a79fed1551e557,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4788271035113731686, guid: 07043005be65ef0468a79fed1551e557,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4788271035113731686, guid: 07043005be65ef0468a79fed1551e557,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4788271035113731686, guid: 07043005be65ef0468a79fed1551e557,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4788271035113731686, guid: 07043005be65ef0468a79fed1551e557,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 07043005be65ef0468a79fed1551e557, type: 3}

--- a/Assets/Test/Scene/testScene.unity
+++ b/Assets/Test/Scene/testScene.unity
@@ -218,6 +218,100 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &511198112
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 511198116}
+  - component: {fileID: 511198115}
+  - component: {fileID: 511198114}
+  - component: {fileID: 511198113}
+  m_Layer: 4
+  m_Name: Plane
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!64 &511198113
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 511198112}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 4
+  m_Convex: 0
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &511198114
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 511198112}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &511198115
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 511198112}
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &511198116
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 511198112}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &957078421
 GameObject:
   m_ObjectHideFlags: 0
@@ -254,7 +348,7 @@ Camera:
   m_Enabled: 1
   serializedVersion: 2
   m_ClearFlags: 1
-  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_BackGroundColor: {r: 0.8880374, g: 0.043137252, b: 1, a: 0}
   m_projectionMatrixMode: 1
   m_GateFitMode: 2
   m_FOVAxisMode: 0
@@ -275,7 +369,7 @@ Camera:
   m_Depth: -1
   m_CullingMask:
     serializedVersion: 2
-    m_Bits: 4294967295
+    m_Bits: 35
   m_RenderingPath: -1
   m_TargetTexture: {fileID: 0}
   m_TargetDisplay: 0

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.rhinox.open.guiutils": "2.8.1",
-    "com.rhinox.open.lightspeed": "1.5.3",
+    "com.rhinox.open.lightspeed": "1.5.8",
     "com.rhinox.open.perceptor": "0.2.0",
     "com.rhinox.open.utilities": "1.5.4",
     "com.unity.ide.rider": "1.2.1",

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,9 +1,9 @@
 {
   "dependencies": {
-    "com.rhinox.open.guiutils": "2.6.2",
+    "com.rhinox.open.guiutils": "2.8.1",
     "com.rhinox.open.lightspeed": "1.5.3",
     "com.rhinox.open.perceptor": "0.2.0",
-    "com.rhinox.open.utilities": "1.5.2",
+    "com.rhinox.open.utilities": "1.5.4",
     "com.unity.ide.rider": "1.2.1",
     "com.unity.ide.visualstudio": "2.0.11",
     "com.unity.ide.vscode": "1.2.3",

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -4,5 +4,14 @@
 EditorBuildSettings:
   m_ObjectHideFlags: 0
   serializedVersion: 2
-  m_Scenes: []
+  m_Scenes:
+  - enabled: 1
+    path: Assets/Test/Scene/testScene.unity
+    guid: 1eb4cb6c565fdbb4f8fa5473448a5a8b
+  - enabled: 1
+    path: Assets/Test/Scene/emptyScene.unity
+    guid: dcc75c62e9b2c404ca564f08bd16532f
+  - enabled: 1
+    path: Assets/Test/Scene/emptyScene2.unity
+    guid: 666827eb0645d3b4098a689e3d2345ec
   m_configObjects: {}

--- a/ProjectSettings/MagnusProjectSettings.asset
+++ b/ProjectSettings/MagnusProjectSettings.asset
@@ -115,3 +115,17 @@ MonoBehaviour:
         _assemblyQualifiedName: Rhinox.Magnus.LayerManager, com.rhinox.open.magnus,
           Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
         _name: LayerManager
+    - Toggled: 1
+      _baseType:
+        _assemblyName: com.rhinox.open.magnus, Version=0.0.0.0, Culture=neutral,
+          PublicKeyToken=null
+        _assemblyQualifiedName: Rhinox.Magnus.CameraInfo, com.rhinox.open.magnus,
+          Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+        _name: CameraInfo
+      _servicePriority: 0
+      ServiceType:
+        _assemblyName: com.rhinox.open.magnus, Version=0.0.0.0, Culture=neutral,
+          PublicKeyToken=null
+        _assemblyQualifiedName: Rhinox.Magnus.CameraInfo, com.rhinox.open.magnus,
+          Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+        _name: CameraInfo

--- a/ProjectSettings/MagnusProjectSettings.asset
+++ b/ProjectSettings/MagnusProjectSettings.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fee6007796dc44ed803676fca0c615fd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  LoadingScenePrefab: {fileID: 5067094718960081199, guid: 1ff27b3acd400fc4e835f9fd206f6e89,
+  LoadingScenePrefab: {fileID: 5067094718960081199, guid: 9378cf271a25ffe41b785b11b386e0f2,
     type: 3}
   PlayerConfig: {fileID: 11400000, guid: 5da32017879a5c343b865b381d87d005, type: 2}
   GameModes: {fileID: 0}

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -17,7 +17,7 @@ PlayerSettings:
   defaultCursor: {fileID: 0}
   cursorHotspot: {x: 0, y: 0}
   m_SplashScreenBackgroundColor: {r: 0.13725491, g: 0.12156863, b: 0.1254902, a: 1}
-  m_ShowUnitySplashScreen: 1
+  m_ShowUnitySplashScreen: 0
   m_ShowUnitySplashLogo: 1
   m_SplashScreenOverlayOpacity: 1
   m_SplashScreenAnimation: 1


### PR DESCRIPTION
### Added
#### Service Commands
- list-service: lists all available services

#### Layer Commands
- list-layers: lists all named layers
- set-layer: sets the layer of a scene object using the LayerManager
- unset-layer: unsets the layer of a scene object using the LayerManager

#### Console Commands
- clear: clears the history of the console (IMGUI only)

#### Level Commands
- list-levels: list all levels included in the current build
- get-level-path: gets path to a level from its name
- load-level: loads the level with target build index (async)
- get-active-level: Gets the path of the current level

#### Player Commands
- kill-player: kills the loaded player
- respawn-player: respawns the player (optional parameters available)

#### Parsers
- Added a string parser for Quaternion, Vector3 and layers (both name and index)

### Fixed
- Public methods in the level loader would throw an exception if the loading scene prefab (in Magnus Project Settings) were not set correctly